### PR TITLE
improve the git branch info details

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -4,7 +4,9 @@
 #   set -g theme_display_git_untracked no
 
 function _git_branch_name
-  echo (command git symbolic-ref HEAD 2> /dev/null | sed -e 's|^refs/heads/||')
+  echo (command git symbolic-ref HEAD 2> /dev/null; \
+       or command git rev-parse --short HEAD 2> /dev/null) \
+       | sed -e 's|^refs/heads/||'
 end
 
 function _is_git_dirty
@@ -32,9 +34,10 @@ function fish_prompt
   end
   set -l cwd $cyan(basename (prompt_pwd))
 
-  if [ (_git_branch_name) ]
-    set -l git_branch $red(_git_branch_name)
-    set git_info "$blue git:($git_branch$blue)"
+  if [ (__fish_git_prompt) ]
+    set -l branch_info (__fish_git_prompt | tr -d '() ')
+    set -l branch_info $red{$branch_info}
+    set git_info "$blue git:($branch_info$blue)"
 
     if [ (_is_git_dirty) ]
       set -l dirty "$yellow ✗"


### PR DESCRIPTION
this patch use fish's `__fish_git_prompt` funciton to get more details in a git repo, it improves the following:

1. show the commit instead of empty branch when checkout to a detached commit
2. show the progress detail when doing rebase|merge|stash process
   eg. run `git rebase -i HEAD~3`, it will show the branch name with a
   rebase step such as `(master|REBASE-i1/3)`

Signed-off-by: Penghui Liao <liaoishere@gmail.com>