### PR TITLE
Fix _is_git_dirty method

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,19 +1,11 @@
 # name: RobbyRussel
-#
-# You can override some default options in your config.fish:
-#   set -g theme_display_git_untracked no
 
 function _git_branch_name
   echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
 end
 
 function _is_git_dirty
-  set -l show_untracked (git config --bool bash.showUntrackedFiles)
-  set untracked ''
-  if [ "$theme_display_git_untracked" = 'no' -o "$show_untracked" = 'false' ]
-    set untracked '--untracked-files=no'
-  end
-  echo (command git status -s --ignore-submodules=dirty $untracked ^/dev/null)
+  echo (command git status --porcelain ^/dev/null)
 end
 
 function fish_prompt
@@ -44,4 +36,3 @@ function fish_prompt
 
   echo -n -s $arrow ' ' $cwd $git_info $normal ' '
 end
-


### PR DESCRIPTION
Before this change this feature was broken and failing to run internal if condition properly.

I think that the 'display' untracked files functionality is redundant here, as the simplest thing we want to know is if repo has some non commited files or not.

So, `git status --porcelain` is very simple replacement to check this.

Similar solution can be found in the other oh-my-fish theme: https://github.com/oh-my-fish/theme-gitstatus