### PR TITLE
Fix git status info to display

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -9,11 +9,11 @@ end
 
 function _is_git_dirty
   set -l show_untracked (git config --bool bash.showUntrackedFiles)
-  set untracked ''
   if [ "$theme_display_git_untracked" = 'no' -o "$show_untracked" = 'false' ]
-    set untracked '--untracked-files=no'
+    echo (command git status -s --ignore-submodules=dirty --untracked-files=no 2> /dev/null)
+  else
+    echo (command git status -s --ignore-submodules=dirty 2> /dev/null)
   end
-  echo (command git status -s --ignore-submodules=dirty $untracked 2> /dev/null)
 end
 
 function fish_prompt


### PR DESCRIPTION
No git status info was shown because of the empty string arg to
git-status.