### PR TITLE
Add --no-optional-locks to `git status`

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -13,7 +13,7 @@ function _is_git_dirty
   if [ "$theme_display_git_untracked" = 'no' -o "$show_untracked" = 'false' ]
     set untracked '--untracked-files=no'
   end
-  echo (command git status -s --ignore-submodules=dirty $untracked 2> /dev/null)
+  echo (command git status -s --no-optional-locks --ignore-submodules=dirty $untracked 2> /dev/null)
 end
 
 function fish_prompt


### PR DESCRIPTION
Previously, calling `git status` would lock the `.git` directory, which would in turn modify its `mtime`.

This causes issues for build systems that look at `.git` to decide whether to rebuild (e.g. [`vergen`](https://docs.rs/vergen/latest/vergen/), which lets you include a Git hash in the output).  Because `.git` was being changed on every new prompt, the build system was recompiling stuff all the time.